### PR TITLE
docs: create swagger docs to products and producer routes

### DIFF
--- a/src/routes/Producer.js
+++ b/src/routes/Producer.js
@@ -7,30 +7,195 @@ import verifyToken from "../middlewares/verifyToken.js";
 const producerRouter = express.Router();
 const producerController = new ProducerController();
 
+/**
+ * @swagger
+ * /producers:
+ *   get:
+ *     summary: Obtiene todos los productores
+ *     tags: [Producers]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de productores obtenida exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       name:
+ *                         type: string
+ *                       email:
+ *                         type: string
+ *                       phone:
+ *                         type: string
+ *                       country:
+ *                         type: string
+ *                       state:
+ *                         type: string
+ *                       farm:
+ *                         type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Productores obtenidos exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 producerRouter.get(
   "/",
-
   verifyToken,
   isAdmin,
-
   producerController.getAllProducers
 );
 
+/**
+ * @swagger
+ * /producers/{id}:
+ *   get:
+ *     summary: Obtiene un productor por ID
+ *     tags: [Producers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del productor
+ *     responses:
+ *       200:
+ *         description: Productor encontrado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     phone:
+ *                       type: string
+ *                     country:
+ *                       type: string
+ *                     state:
+ *                       type: string
+ *                     farm:
+ *                       type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Productor encontrado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 producerRouter.get(
   "/:id",
-
   verifyToken,
   isAdmin,
-
   producerController.getProducerById
 );
 
+/**
+ * @swagger
+ * /producers:
+ *   post:
+ *     summary: Crea un nuevo productor
+ *     tags: [Producers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - email
+ *               - phone
+ *               - country
+ *               - state
+ *               - farm
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *               phone:
+ *                 type: string
+ *               country:
+ *                 type: string
+ *               state:
+ *                 type: string
+ *               farm:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Productor creado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     phone:
+ *                       type: string
+ *                     country:
+ *                       type: string
+ *                     state:
+ *                       type: string
+ *                     farm:
+ *                       type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 201
+ *                 msg:
+ *                   type: string
+ *                   example: "Productor creado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 producerRouter.post(
   "/",
-
   verifyToken,
   isAdmin,
-
   [
     body("name").notEmpty().withMessage("El nombre es requerido"),
     body("email")
@@ -43,16 +208,83 @@ producerRouter.post(
     body("state").notEmpty().withMessage("El estado es requerido"),
     body("farm").notEmpty().withMessage("La finca es requerida"),
   ],
-
   producerController.createProducer
 );
 
+/**
+ * @swagger
+ * /producers/{id}:
+ *   put:
+ *     summary: Actualiza un productor existente
+ *     tags: [Producers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del productor a actualizar
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *               phone:
+ *                 type: string
+ *               country:
+ *                 type: string
+ *               state:
+ *                 type: string
+ *               farm:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Productor actualizado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     email:
+ *                       type: string
+ *                     phone:
+ *                       type: string
+ *                     country:
+ *                       type: string
+ *                     state:
+ *                       type: string
+ *                     farm:
+ *                       type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Productor actualizado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 producerRouter.put(
   "/:id",
-
   verifyToken,
   isAdmin,
-
   [
     body("name")
       .optional()
@@ -79,16 +311,49 @@ producerRouter.put(
       .notEmpty()
       .withMessage("Farm, if provided, cannot be empty."),
   ],
-
   producerController.updateProducer
 );
 
+/**
+ * @swagger
+ * /producers/{id}:
+ *   delete:
+ *     summary: Elimina un productor
+ *     tags: [Producers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del productor a eliminar
+ *     responses:
+ *       200:
+ *         description: Productor eliminado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: null
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Productor eliminado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 producerRouter.delete(
   "/:id",
-
   verifyToken,
   isAdmin,
-
   producerController.deleteProducer
 );
 

--- a/src/routes/Products.js
+++ b/src/routes/Products.js
@@ -10,35 +10,305 @@ const productRouter = express.Router();
 const controller = new ProductController();
 const upload = multer({});
 
+/**
+ * @swagger
+ * /products:
+ *   get:
+ *     summary: Obtiene todos los productos
+ *     tags: [Products]
+ *     responses:
+ *       200:
+ *         description: Lista de productos obtenida exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       name:
+ *                         type: string
+ *                       description:
+ *                         type: string
+ *                       status:
+ *                         type: boolean
+ *                       type:
+ *                         type: string
+ *                       varieties:
+ *                         type: array
+ *                       photos:
+ *                         type: array
+ *                         items:
+ *                           type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Productos obtenidos exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 productRouter.get("/", controller.getAll);
+
+/**
+ * @swagger
+ * /products/{id}:
+ *   get:
+ *     summary: Obtiene un producto por ID
+ *     tags: [Products]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del producto
+ *     responses:
+ *       200:
+ *         description: Producto encontrado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     description:
+ *                       type: string
+ *                     status:
+ *                       type: boolean
+ *                     type:
+ *                       type: string
+ *                     varieties:
+ *                       type: array
+ *                     photos:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Producto encontrado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ *       404:
+ *         description: Producto no encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: null
+ *                 error:
+ *                   type: boolean
+ *                   example: true
+ *                 status:
+ *                   type: number
+ *                   example: 404
+ *                 msg:
+ *                   type: string
+ *                   example: "Producto no encontrado"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 productRouter.get("/:id", controller.getOne);
 
+/**
+ * @swagger
+ * /products:
+ *   post:
+ *     summary: Crea un nuevo producto
+ *     tags: [Products]
+ *     security:
+ *       - bearerAuth: []
+ *     consumes:
+ *       - multipart/form-data
+ *     parameters:
+ *       - in: formData
+ *         name: photos
+ *         type: file
+ *         description: Fotos del producto (máximo 5)
+ *         required: true
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - description
+ *               - type
+ *               - varieties
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               type:
+ *                 type: string
+ *               varieties:
+ *                 type: array
+ *     responses:
+ *       201:
+ *         description: Producto creado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     description:
+ *                       type: string
+ *                     status:
+ *                       type: boolean
+ *                     type:
+ *                       type: string
+ *                     varieties:
+ *                       type: array
+ *                     photos:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 201
+ *                 msg:
+ *                   type: string
+ *                   example: "Producto creado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 productRouter.post(
   "/",
-
   verifyToken,
   isSalesOrAdmin,
-
   upload.array("photos", 5, "No se puede subir más de 5 fotos"),
-
   [
     body("name").notEmpty().withMessage("El nombre es obligatorio"),
     body("description").notEmpty().withMessage("La descripción es obligatoria"),
     body("type").notEmpty().withMessage("El tipo es obligatorio"),
     body("varieties").notEmpty().withMessage("Las variedades son obligatorias"),
   ],
-
   controller.create
 );
 
+/**
+ * @swagger
+ * /products/{id}:
+ *   post:
+ *     summary: Actualiza un producto existente
+ *     tags: [Products]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del producto a actualizar
+ *       - in: formData
+ *         name: newphotos
+ *         type: file
+ *         description: Nuevas fotos del producto (máximo 5)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - description
+ *               - status
+ *               - type
+ *               - varieties
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               status:
+ *                 type: boolean
+ *               type:
+ *                 type: string
+ *               varieties:
+ *                 type: array
+ *     responses:
+ *       200:
+ *         description: Producto actualizado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     description:
+ *                       type: string
+ *                     status:
+ *                       type: boolean
+ *                     type:
+ *                       type: string
+ *                     varieties:
+ *                       type: array
+ *                     photos:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Producto actualizado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 productRouter.post(
   "/:id",
-
   verifyToken,
   isSalesOrAdmin,
-
   upload.array("newphotos", 5, "No se puede subir más de 5 fotos"),
-
   [
     body("name").notEmpty().withMessage("El nombre no puede estar vacío"),
     body("description")
@@ -52,10 +322,45 @@ productRouter.post(
       .isArray()
       .withMessage("Las variedades deben ser un array"),
   ],
-
   controller.update
 );
 
+/**
+ * @swagger
+ * /products/{id}:
+ *   delete:
+ *     summary: Elimina un producto
+ *     tags: [Products]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID del producto a eliminar
+ *     responses:
+ *       200:
+ *         description: Producto eliminado exitosamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: null
+ *                 error:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: number
+ *                   example: 200
+ *                 msg:
+ *                   type: string
+ *                   example: "Producto eliminado exitosamente"
+ *                 timestamp:
+ *                   type: string
+ *                   example: "2024-01-20T15:30:00.000Z"
+ */
 productRouter.delete("/:id", verifyToken, isAdmin, controller.delete);
 
 export default productRouter;


### PR DESCRIPTION
This pull request adds Swagger documentation to the `Producer` and `Product` routes in the project. 

### Swagger Documentation Additions:

* `src/routes/Producer.js`:
  * Added documentation for the `GET /producers` endpoint to retrieve all producers.
  * Added documentation for the `GET /producers/{id}` endpoint to retrieve a producer by ID.
  * Added documentation for the `POST /producers` endpoint to create a new producer.
  * Added documentation for the `PUT /producers/{id}` endpoint to update an existing producer.
  * Added documentation for the `DELETE /producers/{id}` endpoint to delete a producer.

* `src/routes/Products.js`:
  * Added documentation for the `GET /products` endpoint to retrieve all products.
  * Added documentation for the `GET /products/{id}` endpoint to retrieve a product by ID.
  * Added documentation for the `POST /products` endpoint to create a new product.
  * Added documentation for the `POST /products/{id}` endpoint to update an existing product.
  * Added documentation for the `DELETE /products/{id}` endpoint to delete a product.