### PR TITLE
feat: implement Stripe webhook

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -23,7 +23,18 @@ app.use(
   })
 );
 
-app.use(express.json());
+// We need the raw body to verify webhook signatures.
+// Let's compute it only when hitting the Stripe webhook endpoint.
+app.use(
+  express.json({
+    verify: function (req, res, buf) {
+      if (req.originalUrl.startsWith("/api/payments/webhook")) {
+        req.rawBody = buf.toString();
+      }
+    },
+  })
+);
+
 app.use(express.urlencoded({ extended: true }));
 
 app.get("/api", (_, res) => {

--- a/src/controllers/PaymentsController.js
+++ b/src/controllers/PaymentsController.js
@@ -103,6 +103,49 @@ class PaymentsController {
       next(error);
     }
   };
+
+  webhook = async (req, res, next) => {
+    let data;
+    let eventType;
+
+    // Check if webhook signing is configured.
+    if (process.env.STRIPE_WEBHOOK_SECRET) {
+      // Retrieve the event by verifying the signature using the raw body and secret.
+      let event;
+      let signature = req.headers["stripe-signature"];
+
+      try {
+        event = stripe.webhooks.constructEvent(
+          req.rawBody,
+          signature,
+          process.env.STRIPE_WEBHOOK_SECRET
+        );
+      } catch (err) {
+        console.log(`⚠️  Webhook signature verification failed.`);
+        next(err);
+      }
+
+      // Extract the object from the event.
+      data = event.data;
+      eventType = event.type;
+    } else {
+      // Webhook signing is recommended, but if the secret is not configured in `config.js`,
+      // retrieve the event data directly from the request body.
+      data = req.body.data;
+      eventType = req.body.type;
+    }
+
+    if (eventType === "checkout.session.completed") {
+      console.log(`🔔  Payment received!`);
+    }
+
+    const response = new ResponseDataBuilder()
+      .setStatus(200)
+      .setMsg("Webhook received")
+      .build();
+
+    return res.status(response.status).json(response);
+  };
 }
 
 export default PaymentsController;

--- a/src/routes/Payments.js
+++ b/src/routes/Payments.js
@@ -137,4 +137,6 @@ paymentsRouter.post(
   controller.createPayment
 );
 
+paymentsRouter.post("/webhook", controller.webhook);
+
 export default paymentsRouter;


### PR DESCRIPTION
### Stripe webhook integration:

* [`src/app.js`](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L26-R37): Updated the `express.json()` middleware to compute and store the raw request body for requests targeting the `/api/payments/webhook` endpoint. This is necessary for verifying Stripe webhook signatures.

* [`src/controllers/PaymentsController.js`](diffhunk://#diff-b4edca800577740b51c8230d91a6692527915875072ed7b0e8e4e955194846daR106-R148): Added a `webhook` method to handle incoming Stripe webhook events. It verifies the signature using the raw body and a secret key (if configured) and processes the event data. The method logs a message for successful payments and sends a standardized response.

* [`src/routes/Payments.js`](diffhunk://#diff-301361dc3dd5759b2b6e1bf086eb0d45ebd67128e0dc20eff2e9a4e853672d5eR140-R141): Added a new route to handle POST requests to `/webhook`, mapping them to the `webhook` method in `PaymentsController`.